### PR TITLE
Modernize bot

### DIFF
--- a/cogs/meta.py
+++ b/cogs/meta.py
@@ -1,17 +1,25 @@
-import discord
-from discord.ext import commands
+from __future__ import annotations
 
 import datetime
-import humanize
 import sys
 import traceback
+from typing import TYPE_CHECKING
+
+import discord
+import humanize
+from discord.ext import commands
+
+from .utils.context import Context
+
+if TYPE_CHECKING:
+    from bot import Logger
 
 class HelpCommand(commands.MinimalHelpCommand):
     def get_command_signature(self, command):
         return "{0.clean_prefix}{1.qualified_name} {1.signature}".format(self, command)
 
 class Meta(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: Logger):
         self.bot = bot
         self._original_help_command = bot.help_command
         bot.help_command = HelpCommand()
@@ -21,52 +29,60 @@ class Meta(commands.Cog):
         self.bot.help_command = self._original_help_command
 
     @commands.Cog.listener()
-    async def on_command_error(self, ctx, error):
+    async def on_command_error(self, ctx: Context, error):
         print("Ignoring exception in command {}:".format(ctx.command), file=sys.stderr)
         traceback.print_exception(
             type(error), error, error.__traceback__, file=sys.stderr
         )
 
-        if isinstance(error, discord.ext.commands.errors.BotMissingPermissions):
+        if isinstance(error, commands.errors.BotMissingPermissions):
             perms_text = "\n".join(
                 [
                     f"- {perm.replace('_', ' ').capitalize()}"
-                    for perm in error.missing_perms
+                    for perm in error.missing_permissions
                 ]
             )
-            return await ctx.send(f":x: Missing Permissions:\n {perms_text}")
-        elif isinstance(error, discord.ext.commands.errors.BadArgument):
-            return await ctx.send(f":x: {error}")
-        elif isinstance(error, discord.ext.commands.errors.MissingRequiredArgument):
-            return await ctx.send(f":x: {error}")
-        elif isinstance(error, discord.ext.commands.errors.CommandNotFound):
+            return await ctx.send(f":x: Missing Permissions:\n {perms_text}", ephemeral=True)
+        elif isinstance(error, commands.errors.BadArgument):
+            return await ctx.send(f":x: {error}", ephemeral=True)
+        elif isinstance(error, commands.errors.MissingRequiredArgument):
+            return await ctx.send(f":x: {error}", ephemeral=True)
+        elif isinstance(error, commands.errors.CommandNotFound):
             return
-        elif isinstance(error, discord.ext.commands.errors.CheckFailure):
+        elif isinstance(error, commands.errors.CheckFailure):
             return
 
         await ctx.send(f"```py\n{error}\n```")
 
         if isinstance(error, commands.CommandInvokeError):
             em = discord.Embed(title=":warning: Error", description="", color=discord.Color.gold(), timestamp=datetime.datetime.utcnow())
+
+            if TYPE_CHECKING:
+                assert isinstance(em.description, str)
+
             em.description += f"\nCommand: `{ctx.command}`"
             em.description += f"\nLink: [Jump]({ctx.message.jump_url})"
             em.description += f"\n\n```py\n{error}```\n"
 
+            if not isinstance(self.bot.console, discord.abc.Messageable):
+                self.bot.log.warning("Bot console is not messageable.")
+                return
+
             await self.bot.console.send(embed=em)
 
     @commands.command(name="invite", description="Get an invite link")
-    async def invite(self, ctx):
-        invite = discord.utils.oauth_url(self.bot.user.id)
+    async def invite(self, ctx: Context):
+        invite = discord.utils.oauth_url(self.bot.user.id)  # type: ignore
         await ctx.send(f"<{invite}>")
 
-    @commands.command(name="ping", description="Check my latency")
-    async def ping(self, ctx):
+    @commands.hybrid_command(name="ping", description="Check my latency")
+    async def ping(self, ctx: Context):
         await ctx.send(f"My latency is {int(self.bot.latency*1000)}ms")
 
-    @commands.command(name="uptime", description="Check my uptime")
-    async def uptime(self, ctx):
+    @commands.hybrid_command(name="uptime", description="Check my uptime")
+    async def uptime(self, ctx: Context):
         delta = datetime.datetime.utcnow()-self.bot.startup_time
         await ctx.send(f"I started up {humanize.naturaldelta(delta)} ago")
 
-def setup(bot):
-    bot.add_cog(Meta(bot))
+async def setup(bot: Logger) -> None:
+    await bot.add_cog(Meta(bot))

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import discord
 from discord import app_commands
@@ -62,6 +62,7 @@ class Settings(commands.Cog):
         return UserConfig.from_record(record)
 
     @commands.hybrid_command(name="theme")
+    @app_commands.describe(theme="Which theme to change to")
     async def theme(self, ctx: Context, *, theme: ThemeConverter = None):  # type: ignore
         """View or change your theme
 

--- a/cogs/settings.py
+++ b/cogs/settings.py
@@ -1,12 +1,27 @@
-from discord.ext import commands
-import discord
+from __future__ import annotations
 
-from .utils import cache
-from .utils import theme as theme_module
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from .utils import cache, theme as theme_module
+from .utils.context import Context
+
+if TYPE_CHECKING:
+    from typing_extensions import Self, TypeAlias
+
+    from bot import Logger
+
+ThemeConverterRet: TypeAlias = Tuple[theme_module.Theme, Optional[int]]
 
 class UserConfig:
+    id: str
+    theme: theme_module.Theme
+
     @classmethod
-    def from_record(cls, record):
+    def from_record(cls, record: Any) -> Self:
         self = cls()
 
         self.id = record["id"]
@@ -15,8 +30,8 @@ class UserConfig:
         return self
 
 
-class ThemeConverter(commands.Converter):
-    async def convert(self, ctx, arg):
+class ThemeConverter(commands.Converter[ThemeConverterRet]):
+    async def convert(self, ctx: Context, arg: str) -> ThemeConverterRet:
         arg = arg.lower()
 
         for k, v in theme_module.THEME_MAPPING.items():
@@ -29,11 +44,11 @@ class ThemeConverter(commands.Converter):
 class Settings(commands.Cog):
     """Commands to configure the bot"""
 
-    def __init__(self, bot):
+    def __init__(self, bot: Logger) -> None:
         self.bot = bot
 
     @cache.cache()
-    async def fetch_config(self, user_id):
+    async def fetch_config(self, user_id: int) -> Optional[UserConfig]:
         query = """SELECT *
                    FROM user_config
                    WHERE id=$1;
@@ -46,8 +61,8 @@ class Settings(commands.Cog):
 
         return UserConfig.from_record(record)
 
-    @commands.command(name="theme")
-    async def theme(self, ctx, *, theme: ThemeConverter = None):
+    @commands.hybrid_command(name="theme")
+    async def theme(self, ctx: Context, *, theme: ThemeConverter = None):  # type: ignore
         """View or change your theme
 
         Available themes:
@@ -56,11 +71,11 @@ class Settings(commands.Cog):
         """
         if not theme:
             config = await self.fetch_config(ctx.author.id)
-            theme = config.theme if config else theme_module.get_theme(None)
+            theme = config.theme if config else theme_module.get_theme(None)  # type: ignore
 
-            return await ctx.send(f"Your current theme: `{theme}`")
+            return await ctx.send(f"Your current theme: `{theme}`", ephemeral=True)
 
-        theme, theme_id = theme
+        theme, theme_id = theme  # type: ignore
 
         query = """INSERT INTO user_config (id, theme)
                    VALUES ($1, $2) ON CONFLICT (id) DO UPDATE SET
@@ -71,8 +86,20 @@ class Settings(commands.Cog):
 
         self.fetch_config.invalidate(self, ctx.author.id)
 
-        await ctx.send(f"Set theme to `{theme}`")
+        await ctx.send(f"Set theme to `{theme}`", ephemeral=True)
+
+    @theme.autocomplete("theme")
+    async def theme_autocomplete(
+        self,
+        interaction: discord.Interaction,
+        current: str
+    ) -> List[app_commands.Choice[str]]:
+        themes = (str(theme) for theme in theme_module.THEMES)
+        return [
+            app_commands.Choice(name=theme, value=theme)
+            for theme in themes if current.lower() in theme.lower()
+        ]
 
 
-def setup(bot):
-    bot.add_cog(Settings(bot))
+async def setup(bot: Logger) -> None:
+    await bot.add_cog(Settings(bot))

--- a/cogs/tracking.py
+++ b/cogs/tracking.py
@@ -11,6 +11,7 @@ import typing
 import asyncpg
 import discord
 import humanize
+from discord import app_commands
 from discord.ext import commands, tasks
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 
@@ -345,6 +346,7 @@ class Tracking(commands.Cog):
             await self.bot.db.execute(query, user.id, None)
 
     @commands.hybrid_command(name="names", description="View past usernames for a user")
+    @app_commands.describe(user="Who's username history to show")
     async def names(self, ctx: Context, *, user: discord.Member = None):  # type: ignore
         if not user:
             user = ctx.author  # type: ignore
@@ -368,6 +370,7 @@ class Tracking(commands.Cog):
             await ctx.send(page)
 
     @commands.hybrid_command(name="nicks", description="View past nicknames for a user")
+    @app_commands.describe(user="Who's nickname history to show")
     async def nicks(self, ctx: Context, *, user: discord.Member = None):  # type: ignore
         if not user:
             user = ctx.author  # type: ignore
@@ -394,6 +397,7 @@ class Tracking(commands.Cog):
             await ctx.send(page)
 
     @commands.hybrid_command(name="avatars")
+    @app_commands.describe(user="Who's avatar history to show")
     async def avatars(self, ctx: Context, *, user: discord.Member = None):  # type: ignore
         """View past avatars for a user"""
 
@@ -466,6 +470,7 @@ class Tracking(commands.Cog):
         return file
 
     @commands.hybrid_command(name="avatar", description="View a specific avatar in history")
+    @app_commands.describe(user="Who's avatar to show", avatar="The index of the avatar in history")
     async def avatar(self, ctx: Context, user: typing.Optional[discord.Member], avatar: int = 1):
         if not user:
             user = ctx.author
@@ -492,6 +497,7 @@ class Tracking(commands.Cog):
         await ctx.send(content=f"Hash: {avatar['hash']}", embed=em, file=discord.File(f"images/{avatar['filename']}", filename="image.png"))
 
     @commands.hybrid_command(name="pie", description="View a user's presence pie chart")
+    @app_commands.describe(user="Who's pie chart to show")
     async def pie(self, ctx: Context, *, user: discord.Member = None):
         if not user:
             user = ctx.author
@@ -523,6 +529,7 @@ class Tracking(commands.Cog):
         await ctx.send(content=f"Pie chart for {user}", file=discord.File(file, filename="pie.png"))
 
     @commands.hybrid_command(name="ring", description="View a user's presence ring", aliases=["avatarpie"])
+    @app_commands.describe(user="Who's ring chart to show")
     async def ring(self, ctx: Context, *, user: discord.Member = None):
         if not user:
             user = ctx.author
@@ -613,6 +620,7 @@ class Tracking(commands.Cog):
         return image
 
     @commands.hybrid_command(name="chart", description="View a chart of your status over the past month")
+    @app_commands.describe(user="Who's status chart to show")
     async def chart(self, ctx: Context, *, user: discord.Member = None):
         if not user:
             user = ctx.author
@@ -644,6 +652,7 @@ class Tracking(commands.Cog):
         await ctx.send(content=f"Status chart for {user} during the past 30 days", file=discord.File(file, filename="chart.png"))
 
     @commands.hybrid_command(name="chartfor", description="View a chart of your status for a specified time period")
+    @app_commands.describe(user="Who's status chart to show", month="Which month to show", year="Which year to show")
     async def chart_for(
         self,
         ctx: Context,

--- a/cogs/utils/cache.py
+++ b/cogs/utils/cache.py
@@ -6,14 +6,19 @@ License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
 
+from __future__ import annotations
 
 import asyncio
-import inspect
 import functools
+import inspect
 from collections import OrderedDict
+from typing import Any, Callable, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
 
 
-class LRUDict(OrderedDict):
+class LRUDict(OrderedDict[K, V]):
     """A dict with a maximum length which removes items in LRU fashon.
 
     This inherits from :class:`collections.OrderedDict`
@@ -29,14 +34,14 @@ class LRUDict(OrderedDict):
         Defaults to 10
     """
 
-    def __init__(self, max_len: int = 10, *args, **kwargs):
+    def __init__(self, max_len: int = 10, *args: Any, **kwargs: Any) -> None:
         if max_len <= 0:
             raise ValueError()
         self.max_len = max_len
 
         super().__init__(*args, **kwargs)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: K, value: V) -> None:
         super().__setitem__(key, value)
         super().move_to_end(key)
 
@@ -44,7 +49,7 @@ class LRUDict(OrderedDict):
             oldkey = next(iter(self))
             super().__delitem__(oldkey)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: K) -> V:
         val = super().__getitem__(key)
         super().move_to_end(key)
 
@@ -69,7 +74,7 @@ def _wrap_value(value):
     return func()
 
 
-def cache(max_len: int = 128, *, ignore_kwargs=False):
+def cache(max_len: int = 128, *, ignore_kwargs: bool = False):
     """A cache that wraps a func and uses :class:`LRUDict` to store the returning value.
 
     Don't create an instance of this directly.
@@ -124,7 +129,7 @@ def cache(max_len: int = 128, *, ignore_kwargs=False):
         Whether to ignore kwargs when resolving the key
     """
 
-    def decorator(func):
+    def decorator(func: Callable):
         _cache = LRUDict(max_len)
 
         def _resolve_key(args, kwargs):

--- a/cogs/utils/context.py
+++ b/cogs/utils/context.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Union
+
+from discord.context_managers import Typing
+from discord.ext import commands
+
+
+class NotTyping:
+
+    async def __aenter__(self) -> None:
+        pass
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class Context(commands.Context[commands.Bot]):
+
+    def maybe_typing(self)-> Union[Typing, NotTyping]:
+        if self.interaction is None or self.interaction.is_expired():
+            return Typing(self)
+        else:
+            return NotTyping()

--- a/cogs/utils/formats.py
+++ b/cogs/utils/formats.py
@@ -1,28 +1,33 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+
 class plural:
-    def __init__(self, value):
+    def __init__(self, value: int) -> None:
         self.value = value
 
-    def __format__(self, format_spec):
+    def __format__(self, format_spec: str) -> str:
         if self.value == 1:
             return f"{self.value} {format_spec}"
         else:
             return f"{self.value} {format_spec}s"
 
 class Tabulate:
-    def __init__(self):
-        self.widths = []
-        self.columns = []
-        self.rows = []
+    def __init__(self) -> None:
+        self.widths: List[int] = []
+        self.columns: List[str] = []
+        self.rows: List[List[str]] = []
 
-    def add_column(self, column):
+    def add_column(self, column: str) -> None:
         self.columns.append(column)
         self.widths.append(len(column) + 2)
 
-    def add_columns(self, columns):
+    def add_columns(self, columns: List[str]) -> None:
         for column in columns:
             self.add_column(column)
 
-    def add_row(self, row):
+    def add_row(self, row: List[Any]) -> None:
         values = [str(value) for value in row]
         self.rows.append(values)
         for counter, value in enumerate(values):
@@ -30,15 +35,15 @@ class Tabulate:
             if width > self.widths[counter]:
                 self.widths[counter] = width
 
-    def add_rows(self, rows):
+    def add_rows(self, rows: List[List[Any]]):
         for row in rows:
             self.add_row(row)
 
-    def draw_row(self, row):
+    def draw_row(self, row: List[str]) -> str:
         drawing = "║".join([f"{value:^{self.widths[counter]}}" for counter, value in enumerate(row)])
         return f"║{drawing}║"
 
-    def draw(self):
+    def draw(self) -> str:
         top = "╦".join(["═"*width for width in self.widths])
         top = f"╔{top}╗"
 
@@ -58,8 +63,8 @@ class Tabulate:
 
         return "\n".join(drawing)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.draw()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.draw()

--- a/cogs/utils/menus.py
+++ b/cogs/utils/menus.py
@@ -1,24 +1,30 @@
+from typing import Optional
+
+import discord
 from discord.ext import menus
 
+from .context import Context
+
+
 class Confirm(menus.Menu):
-    def __init__(self, msg):
+    def __init__(self, msg: str) -> None:
         super().__init__(timeout=30.0, delete_message_after=True)
         self.msg = msg
         self.result = None
 
-    async def send_initial_message(self, ctx, channel):
+    async def send_initial_message(self, ctx: Context, channel: discord.abc.Messageable) -> discord.Message:
         return await channel.send(self.msg)
 
     @menus.button("\N{WHITE HEAVY CHECK MARK}")
-    async def do_confirm(self, payload):
+    async def do_confirm(self, payload: discord.RawReactionActionEvent) -> None:
         self.result = True
         self.stop()
 
     @menus.button("\N{CROSS MARK}")
-    async def do_deny(self, payload):
+    async def do_deny(self, payload: discord.RawReactionActionEvent) -> None:
         self.result = False
         self.stop()
 
-    async def prompt(self, ctx):
+    async def prompt(self, ctx: Context) -> Optional[bool]:
         await self.start(ctx, wait=True)
         return self.result

--- a/cogs/utils/theme.py
+++ b/cogs/utils/theme.py
@@ -1,23 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    Color: TypeAlias = Tuple[int, int, int]
+
 class Theme:
-    def __init__(self, name, primary, secondary, background):
+
+    def __init__(self, name: str, primary: Color, secondary: Color, background: Color) -> None:
         self.name = name
         self.primary = primary
         self.secondary = secondary
         self.background = background
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
 DARK = Theme("dark", (255, 255, 255), (185, 185, 185), (54, 57, 63))
 LIGHT = Theme("light", (0, 0, 0), (64, 64, 64), (255, 255, 255))
 
-THEME_MAPPING = {
+THEME_MAPPING: Dict[Optional[int], Theme] = {
     None: DARK,  # default theme
     0: DARK,
     1: LIGHT
 }
+THEMES: List[Theme] = [DARK, LIGHT]
 
 
-def get_theme(theme):
-    return THEME_MAPPING[theme]
+def get_theme(theme_id: Optional[int]) -> Theme:
+    return THEME_MAPPING[theme_id]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-discord.py
-jishaku
+git+https://github.com/Rapptz/discord.py.git@69b12b97c0a3f24d8dae92f855c7ab507095edc9
+jishaku>=2.4
 psutil
 asyncpg
 humanize


### PR DESCRIPTION
This PR:
* Migrates the bot to discord.py v2
* Adds slash commands to the bot (along with regular commands)

Migrating to discord.py v2 involved updating `User.avatar` and `Asset` usage, changing cogs and extensions to be async, and migrating bot startup functionality over to the `setup_hook` method. Please also note that the versions of both discord.py and jishaku have been bumped.

When adding slash command support, I made a new `Context` subclass which has a method to only send typing requests if a regular command was invoked. I found it strange to have the bot typing during a slash command. The `theme` command has been updated to send ephemeral messages (to reduce clutter, I guess), and the bot also sends error messages and as ephemeral messages.

I also sorted the imports with [isort](https://github.com/PyCQA/isort). I started to type-hint the bot but didn't finish.